### PR TITLE
Use const char* instead of char*

### DIFF
--- a/src/termbox.c
+++ b/src/termbox.c
@@ -318,7 +318,7 @@ void tb_char(int x, int y, tb_color fg, tb_color bg, tb_chr ch) {
   tb_cell(x, y, &c);
 }
 
-int tb_string_with_limit(int x, int y, tb_color fg, tb_color bg, char *str, int limit) {
+int tb_string_with_limit(int x, int y, tb_color fg, tb_color bg, const char *str, int limit) {
   tb_chr uni;
   int w, c = 0, l = 0;
 
@@ -334,7 +334,7 @@ int tb_string_with_limit(int x, int y, tb_color fg, tb_color bg, char *str, int 
   return l;
 }
 
-int tb_string(int x, int y, tb_color fg, tb_color bg, char *str) {
+int tb_string(int x, int y, tb_color fg, tb_color bg, const char *str) {
   return tb_string_with_limit(x, y, fg, bg, str, MAX_LIMIT);
 }
 

--- a/src/termbox.h
+++ b/src/termbox.h
@@ -214,9 +214,9 @@ SO_IMPORT void tb_send(const char * str);
 SO_IMPORT void tb_sendf(const char * fmt, ...);
 
 /* Set string starting at specific position */
-SO_IMPORT int tb_string(int x, int y, tb_color fg, tb_color bg, char * str);
+SO_IMPORT int tb_string(int x, int y, tb_color fg, tb_color bg, const char * str);
 
-SO_IMPORT int tb_string_with_limit(int x, int y, tb_color fg, tb_color bg, char * str, int limit);
+SO_IMPORT int tb_string_with_limit(int x, int y, tb_color fg, tb_color bg, const char * str, int limit);
 
 /* Same as above but with format and arguments (printf-style) */
 SO_IMPORT int tb_stringf(int x, int y, tb_color fg, tb_color bg, const char * fmt, ...);


### PR DESCRIPTION
There's no real reason why these strings should be mutable, plus it throws warnings when you try to do something very basic like this:

```c++
tb_string(0, 0, TB_WHITE, TB_DEFAULT, "Hello!");
```