### PR TITLE
Fix -Wunused-but-set-variable warning.

### DIFF
--- a/src/termbox.c
+++ b/src/termbox.c
@@ -320,13 +320,12 @@ void tb_char(int x, int y, tb_color fg, tb_color bg, tb_chr ch) {
 
 int tb_string_with_limit(int x, int y, tb_color fg, tb_color bg, const char *str, int limit) {
   tb_chr uni;
-  int w, c = 0, l = 0;
+  int w, l = 0;
 
   while (*str && l < limit) {
     str += tb_utf8_char_to_unicode(&uni, str);
     tb_char(x, y, fg, bg, uni);
     w = tb_unicode_is_char_wide(uni) ? 2 : 1;
-    c++;
     x++;
     l = l + w;
   }


### PR DESCRIPTION
Recent clang (I'm using `Apple clang version 16.0.0 (clang-1600.0.26.6)` that ships with macOS) fails to build with this new warning:

```
src/termbox.c:323:10: error: variable 'c' set but not used [-Werror,-Wunused-but-set-variable]
  323 |   int w, c = 0, l = 0;
      |          ^
1 error generated.
```